### PR TITLE
Conductance Constants

### DIFF
--- a/aedttest/simulation_data.py
+++ b/aedttest/simulation_data.py
@@ -276,7 +276,7 @@ def extract_design_data(app, design_name, setup_dict, project_dir, design_dict):
             design_dict[design_name]["mesh"][variation_name][setup] = mesh_data
 
             profile_file = generate_unique_file_path(project_dir, ".prof")
-            app.export_profile(setup, variation_string, profile_file)
+            profile_file = app.export_profile(setup, variation_string, profile_file)
             simulation_time = parse_profile_file(profile_file, design_name, variation_name, setup)
             design_dict[design_name]["simulation_time"][variation_name][setup] = simulation_time
 


### PR DESCRIPTION
In Q3D, there are more than 1 mesh depending on the setup selected (DC, RL...), the solution, for now, is to choose the latest mesh created (CG or DC...). PyAEDT is working as expected, IT is creating a mesh file per setup. But aedt-testing does not expect more than one msstat file per solution, so the solution for now is just take the mesh from the last setup type. This is compatible with the current pyAEDT main.