### PR TITLE
pass all environment via Intel MPI.

### DIFF
--- a/aedttest/aedt_test_runner.py
+++ b/aedttest/aedt_test_runner.py
@@ -954,7 +954,7 @@ def execute_aedt(
     if platform.system() == "Linux":
         logger.debug("Execute via Intel MPI")
         mpi_path = get_intel_mpi_path(version)
-        command = [mpi_path, "-envnone", "-n", "1", "-hosts", list(machines.keys())[0]] + command
+        command = [mpi_path, "-envall", "-n", "1", "-hosts", list(machines.keys())[0]] + command
 
     logger.debug(f"Execute {subprocess.list2cmdline(command)}")
     output = subprocess.check_output(command)

--- a/tests/unittests/test_aedt_test_runner.py
+++ b/tests/unittests/test_aedt_test_runner.py
@@ -220,7 +220,7 @@ def test_execute_aedt(mock_mpi_path, mock_aedt_path, mock_platform, mock_call):
 
     assert mock_call.call_args[0][0] == [
         "aedt/install/path/mpiexec",
-        "-envnone",
+        "-envall",
         "-n",
         "1",
         "-hosts",


### PR DESCRIPTION
 AEDT should handle it well and take only required nodes via tight integration with scheduler